### PR TITLE
Fix broken link to point to new course

### DIFF
--- a/responses/08_graceful-exit.md
+++ b/responses/08_graceful-exit.md
@@ -21,7 +21,7 @@ Now that you've moved your Git repository to GitHub, managing your repository an
 Hosting a project on GitHub enables you to share your work with millions of other developers. This course will walk you through the different items you can add to your repository to welcome new contributors and make it easier for them to report issues, suggest new features, or potentially submit a pull request!
 
 [Create a release based workflow]({{ host }}/courses/create-a-release-based-workflow)
-Now that you have a repository on GitHub learn about two features of the Settings tab that protect your deployed code. 
+Now that you have a repository on GitHub learn how to utilize a release workflow to create new releases for your project through an efficient development workflow.
 
 There's so much more you can do with GitHub, and you have a solid start. Now...[what will you learn next]({{ host }}/courses)?
 


### PR DESCRIPTION
[Protected Branches and CODEOWNERS]({{ host }}/courses/protected-branches-codeowners)
👆 was not released thus the link was broken. Updated to point to the new course

Closes #9  