### PR TITLE
Add note mentioning SSH connection possibility to GitHub

### DIFF
--- a/responses/02_move-local.md
+++ b/responses/02_move-local.md
@@ -19,7 +19,7 @@ Having a project already stored locally enables you to move it to GitHub rather 
   4. Type `git commit -m "initializing repository"`
   5. Type `git push -u origin master` to push the files you have locally to the remote on GitHub. (You may be asked to log in.)
 
-  **Note:** You can also use a password protected SSH key to connect to GitHub. See the [Connecting to Githug with SSH](https://help.github.com/en/github/authenticating-to-github/connecting-to-github-with-ssh) in our documentation to learn more.
+  **Note:** You can also use a password protected SSH key to connect to GitHub. See [Connecting to Githug with SSH](https://help.github.com/en/github/authenticating-to-github/connecting-to-github-with-ssh) in our documentation to learn more.
 
   <hr>
 </details>

--- a/responses/02_move-local.md
+++ b/responses/02_move-local.md
@@ -19,6 +19,8 @@ Having a project already stored locally enables you to move it to GitHub rather 
   4. Type `git commit -m "initializing repository"`
   5. Type `git push -u origin master` to push the files you have locally to the remote on GitHub. (You may be asked to log in.)
 
+  **Note:** You can also use a password protected SSH key to connect to GitHub. See the [Connecting to Githug with SSH](https://help.github.com/en/github/authenticating-to-github/connecting-to-github-with-ssh) in our documentation to learn more.
+
   <hr>
 </details>
 
@@ -29,9 +31,9 @@ Having a project already stored locally enables you to move it to GitHub rather 
   ### Using GitHub Desktop
 
   1. In GitHub Desktop, add a local repository by clicking `File > Add a Local Repository`, and then navigating to your local repository.
-  1. Create your first commit by typing a summary commit message in the field provided and clicking **Commit to master**
-  2. Add the remote by clicking `Repository > Repository Settings...` and pasting the URL from your repository on GitHub into the "Primary remote repository (origin)" field. Click **Save**.
-  3. Click **Publish** in the top right corner to push your repository to GitHub.
+  2. Create your first commit by typing a summary commit message in the field provided and clicking **Commit to master**
+  3. Add the remote by clicking `Repository > Repository Settings...` and pasting the URL from your repository on GitHub into the "Primary remote repository (origin)" field. Click **Save**.
+  4. Click **Publish** in the top right corner to push your repository to GitHub.
 
   <hr>
 </details>


### PR DESCRIPTION
This PR addresses issue #20.  A note has been added to remind the learner that connection to GitHub using SSH is available.