### PR TITLE
Fix typo and inconsistent spelling in step 2

### DIFF
--- a/responses/02_move-local.md
+++ b/responses/02_move-local.md
@@ -19,7 +19,7 @@ Having a project already stored locally enables you to move it to GitHub rather 
   4. Type `git commit -m "initializing repository"`
   5. Type `git push -u origin master` to push the files you have locally to the remote on GitHub. (You may be asked to log in.)
 
-  **Note:** You can also use a password protected SSH key to connect to GitHub. See [Connecting to Github with SSH](https://help.github.com/en/github/authenticating-to-github/connecting-to-github-with-ssh) in our documentation to learn more.
+  **Note:** You can also use a password protected SSH key to connect to GitHub. See [Connecting to GitHub with SSH](https://help.github.com/en/github/authenticating-to-github/connecting-to-github-with-ssh) in our documentation to learn more.
 
   <hr>
 </details>

--- a/responses/02_move-local.md
+++ b/responses/02_move-local.md
@@ -19,7 +19,7 @@ Having a project already stored locally enables you to move it to GitHub rather 
   4. Type `git commit -m "initializing repository"`
   5. Type `git push -u origin master` to push the files you have locally to the remote on GitHub. (You may be asked to log in.)
 
-  **Note:** You can also use a password protected SSH key to connect to GitHub. See [Connecting to Githug with SSH](https://help.github.com/en/github/authenticating-to-github/connecting-to-github-with-ssh) in our documentation to learn more.
+  **Note:** You can also use a password protected SSH key to connect to GitHub. See [Connecting to Github with SSH](https://help.github.com/en/github/authenticating-to-github/connecting-to-github-with-ssh) in our documentation to learn more.
 
   <hr>
 </details>


### PR DESCRIPTION
Found this typo a while back and noticed it hadn't been caught yet, so here's a PR for it. 🙂

### What is this PR for?

Fixing a typo and inconsistent spelling in `02_move-local.md` file, _Line 22_ `Githug > GitHub`.